### PR TITLE
Update scripts for repackaged nms

### DIFF
--- a/scripts/generatesources.sh
+++ b/scripts/generatesources.sh
@@ -15,18 +15,18 @@ paperVer=$(cat current-paper)
 minecraftversion=$(cat $basedir/Paper/work/BuildData/info.json | grep minecraftVersion | cut -d '"' -f 4)
 decompile="Paper/work/Minecraft/$minecraftversion/spigot"
 
-mkdir -p mc-dev/src/net/minecraft/server
+mkdir -p mc-dev/src/net/minecraft
 
 cd mc-dev
 if [ ! -d ".git" ]; then
 	git init
 fi
 
-rm src/net/minecraft/server/*.java
-cp $basedir/$decompile/net/minecraft/server/*.java src/net/minecraft/server
+rm src/net/minecraft/*.java
+cp $basedir/$decompile/net/minecraft/*.java src/net/minecraft
 
-base="$basedir/Paper/Paper-Server/src/main/java/net/minecraft/server"
-cd $basedir/mc-dev/src/net/minecraft/server/
+base="$basedir/Paper/Paper-Server/src/main/java/net/minecraft"
+cd $basedir/mc-dev/src/net/minecraft/
 for file in $(/bin/ls $base)
 do
 	if [ -f "$file" ]; then

--- a/scripts/importmcdev.sh
+++ b/scripts/importmcdev.sh
@@ -12,10 +12,58 @@ workdir=$basedir/Paper/work
 minecraftversion=$(cat $basedir/Paper/work/BuildData/info.json | grep minecraftVersion | cut -d '"' -f 4)
 decompiledir=$workdir/Minecraft/$minecraftversion/spigot
 
-nms="net/minecraft/server"
+nms="net/minecraft"
 export MODLOG=""
 cd $basedir
 
+export importedmcdev=""
+function import {
+	export importedmcdev="$importedmcdev $1"
+	file="${1}.java"
+	target="$basedir/Paper/Paper-Server/src/main/java/$nms/$file"
+	base="$decompiledir/$nms/$file"
+
+	if [ ! -f "$target" ]; then
+	  export MODLOG="$MODLOG  Imported $file from mc-dev\n";
+		echo "$(bashColor 1 32) Copying $(bashColor 1 34)$base $(bashColor 1 32)to$(bashColor 1 34) $target $(bashColorReset)"
+		mkdir -p "$(dirname "$target")"
+		cp "$base" "$target" || exit 1
+	else
+	  echo "$(bashColor 1 33) UN-NEEDED IMPORT STATEMENT:$(bashColor 1 34) $file $(bashColorReset)"
+	fi
+}
+
+function importLibrary {
+    group=$1
+    lib=$2
+    prefix=$3
+    shift 3
+    for file in "$@"; do
+        file="$prefix/$file"
+        target="$basedir/Paper/Paper-Server/src/main/java/${file}"
+        targetdir=$(dirname "$target")
+        mkdir -p "${targetdir}"
+        base="$workdir/Minecraft/$minecraftversion/libraries/${group}/${lib}/$file"
+        if [ ! -f "$base" ]; then
+            echo "Missing $base"
+            exit 1
+        fi
+        export MODLOG="$MODLOG  Imported $file from $lib\n";
+        sed 's/\r$//' "$base" > "$target" || exit 1
+    done
+}
+
+(
+	cd "$basedir/Paper/Paper-Server/"
+	lastlog=$(git log -1 --oneline)
+	if [[ "$lastlog" = *"Extra mc-dev Imports"* ]]; then
+		git reset --hard HEAD^
+	fi
+)
+
+files=$(cat "$basedir/patches/server/"* | grep "+++ b/src/main/java/net/minecraft/" | sort | uniq | sed 's/\+\+\+ b\/src\/main\/java\/net\/minecraft\///g')
+
+nonnms=$(grep -R "new file mode" -B 1 "$basedir/patches/server/" | grep -v "new file mode" | grep -oE --color=none "net\/minecraft\/.*.java" | sed 's/.*\/net\/minecraft\///g')
 function containsElement {
 	local e
 	for e in "${@:2}"; do
@@ -23,52 +71,23 @@ function containsElement {
 	done
 	return 1
 }
-
-export importedmcdev=""
-function import {
-	if [ -f "$basedir/Paper/Paper-Server/src/main/java/net/minecraft/server/$1.java" ]; then
-		echo "ALREADY IMPORTED $1"
-		return 0
-	fi
-	export importedmcdev="$importedmcdev $1"
-	file="${1}.java"
-	target="$basedir/Paper/Paper-Server/src/main/java/$nms/$file"
-	base="$decompiledir/$nms/$file"
-
-	if [[ ! -f "$target" ]]; then
-		export MODLOG="$MODLOG  Imported $file from mc-dev\n";
-		echo "$(bashColor 1 32) Copying $(bashColor 1 34)$base $(bashColor 1 32)to$(bashColor 1 34) $target $(bashColorReset)"
-		cp "$base" "$target"
-	else
-		echo "$(bashColor 1 33) UN-NEEDED IMPORT STATEMENT:$(bashColor 1 34) $file $(bashColorReset)"
-	fi
-}
-
-(
-	cd Paper/Paper-Server/
-	lastlog=$(git log -1 --oneline)
-	if [[ "$lastlog" = *"EMC-Extra mc-dev Imports"* ]]; then
-		git reset --hard HEAD^
-	fi
-)
-
-
-files=$(cat patches/server/* | grep "+++ b/src/main/java/net/minecraft/server/" | sort | uniq | sed 's/\+\+\+ b\/src\/main\/java\/net\/minecraft\/server\///g' | sed 's/.java//g')
-
-nonnms=$(cat patches/server/* | grep "create mode " | grep -Po "src/main/java/net/minecraft/server/(.*?).java" | sort | uniq | sed 's/src\/main\/java\/net\/minecraft\/server\///g' | sed 's/.java//g')
-
 for f in $files; do
 	containsElement "$f" ${nonnms[@]}
 	if [ "$?" == "1" ]; then
-		if [ ! -f "$basedir/Paper/Paper-Server/src/main/java/net/minecraft/server/$f.java" ]; then
+		if [ ! -f "$basedir/Paper/Paper-Server/src/main/java/net/minecraft/$f" ]; then
+			f="$(echo "$f" | sed 's/.java//g')"
 			if [ ! -f "$decompiledir/$nms/$f.java" ]; then
 				echo "$(bashColor 1 31) ERROR!!! Missing NMS$(bashColor 1 34) $f $(bashColorReset)";
+				error=true
 			else
 				import $f
 			fi
 		fi
 	fi
 done
+if [ -n "$error" ]; then
+  exit 1
+fi
 
 ###############################################################################################
 ###############################################################################################
@@ -79,9 +98,24 @@ done
 # import Foo
 
 ################
+
+########################################################
+########################################################
+########################################################
+#              LIBRARY IMPORTS
+# These must always be mapped manually, no automatic stuff
+#
+# importLibrary    # group    # lib          # prefix               # many files
+# importLibrary com.mojang datafixerupper com/mojang/datafixers/types Type.java
+
+# dont forget \ at end of each line but last
+
+########################################################
+########################################################
+########################################################
 (
-	cd Paper/Paper-Server/
+	cd $basedir/Paper/Paper-Server/
 	rm -rf nms-patches
 	git add src -A
-	echo -e "EMC-Extra mc-dev Imports\n\n$MODLOG" | git commit src -F -
+	echo -e "Extra mc-dev Imports\n\n$MODLOG" | git commit src -F -
 )


### PR DESCRIPTION
Simple update to the scripts which updates the importmcdev.sh and generatesources.sh scripts to be in line with Paper's handling of net/minecraft/server being repackaged.